### PR TITLE
Protect the default branch of github-mgmt

### DIFF
--- a/github/ipfs-examples.yml
+++ b/github/ipfs-examples.yml
@@ -72,6 +72,14 @@ repositories:
     allow_squash_merge: true
     archived: false
     auto_init: false
+    branch_protection:
+      master:
+        required_pull_request_reviews:
+          required_approving_review_count: 1
+        required_status_checks:
+          contexts:
+            - Comment
+          strict: true
     default_branch: master
     delete_branch_on_merge: false
     has_downloads: true


### PR DESCRIPTION
### Summary
Protect default branch of this repository.

### Why do you need this?
To keep github-mgmt secure.

### What else do we need to know?
n/a

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
