### PR TITLE
Create github-mgmt stewards team

### DIFF
--- a/docs/STEWARDSHIP.md
+++ b/docs/STEWARDSHIP.md
@@ -1,0 +1,34 @@
+_NOTE: This document is, and quite likely will always be, a work in progress. You can, and should, contribute to it to make as useful for GitHub Management Stewards as it can be._
+
+# GitHub Management Steward
+
+`github-mgmt stewards` is a team of people who are responsible for managing the GitHub Management configuration for the organization. They have write access to the GitHub Management repository, can review change requests and merge changes to the `master` branch.
+
+Membership in the `github-mgmt stewards` team should be treated with **exactly as much care as having admin access to the organization**.
+
+## What qualifications are expected from a GitHub Management Steward?
+
+- familiarity with [GitHub Management](ABOUT.md)
+- availability for reviews and merges of GitHub Management configuration changes
+- being a trusted member of the organization
+
+## What is expected from a GitHub Management Steward?
+
+- review and merge changes to the GitHub Management configuration
+
+### How to review and merge a GitHub Management pull request?
+
+- Wait for the `Comment` check to pass
+- Verify that the pull request contains only the changes you expect
+- Verify that the plan posted as a comment introduces **only** the changes you expect
+- Check if there are any open PRs created by the `Sync` workflow (titles starting with `sync`) and merge them first if there are
+- Ask the author of the pull request to provide more context if needed
+- Merge the pull request if everything checks out and verify that the `Apply` workflow initiated by the merge succeeded
+
+## How to become a GitHub Management Steward?
+
+To become a GitHub Management Steward, you should meet the [qualifications](#what-qualifications-are-expected-from-a-github-management-steward) and ask one of the existing stewards to approve your change request which adds you to the `github-mgmt stewards` team.
+
+## What do I do if...?
+
+GitHub Management is a relatively new project, GitHub APIs are constantly evolving and the GitHub Management configuration is a living document. You will likely encounter situations that are not covered by this document nor [HOWTOs](HOWTOS.md). If you do and you're unsure what to do, please reach out to @ipfs-examples/ipdx.

--- a/github/ipfs-examples.yml
+++ b/github/ipfs-examples.yml
@@ -66,6 +66,7 @@ repositories:
     visibility: public
     vulnerability_alerts: false
   github-mgmt:
+    # WARN: push+ access here should be treated exactly as cautiosly as org admin role
     allow_auto_merge: false
     allow_merge_commit: true
     allow_rebase_merge: true
@@ -82,14 +83,30 @@ repositories:
           strict: true
     default_branch: master
     delete_branch_on_merge: false
+    files:
+      CODEOWNERS:
+        content: |
+          # The ipdx team is responsible for GitHub Management maintenance
+          * @ipfs-examples/ipdx
+          # The github-mgmt stewards team is responsible for triaging/reviewing configuration change requests
+          # The ipdx team is added here temporarily to witness use patterns in github-mgmt
+          /github/ipfs-examples.yml @ipfs-examples/github-mgmt-stewards @ipfs-examples/ipdx
     has_downloads: true
     has_issues: true
     has_projects: true
     has_wiki: true
     is_template: false
+    teams:
+      # ATTN: do not add teams with push+ access, use github-mgmt stewards team membership instead
+      maintain:
+        - ipdx # NOTE: ipdx are the creators of GitHub Management framework
+      push:
+        - github-mgmt stewards
     template:
       owner: protocol
       repository: github-mgmt-template
+    topics:
+      - ipdx
     visibility: public
     vulnerability_alerts: false
   js-ipfs-101:
@@ -808,3 +825,22 @@ repositories:
       repository: example-fork-go-template
     visibility: public
     vulnerability_alerts: false
+teams:
+  github-mgmt stewards:
+    # NOTE: created to capture users with push+ access to github-mgmt repository
+    #  using a team instead of direct collaborators because we want to reference it in the CODEOWNERS file
+    create_default_maintainer: false
+    description: Users that are effectively org admins
+    members:
+      # WARN: membership here should be treated exactly as cautiously as having an org admin role
+      # ATTN: members are expected to:
+      #  - be familiar with GitHub Management
+      #  - be ready to triage/review org configuration change request in github-mgmt
+      maintainer:
+        - 2color
+    privacy: closed
+  ipdx:
+    members:
+      maintainer:
+        - galargh
+    privacy: closed


### PR DESCRIPTION
### Summary
Similarly to https://github.com/ipfs/github-mgmt/pull/37, we're creating a github-mgmt stewards team that should be responsible for triaging and merging PRs in this repository.

There is a [guide](https://github.com/ipfs-examples/github-mgmt/blob/galargh-patch-1/docs/STEWARDSHIP.md) on the responsibilities of github-mgmt steward hosted in this repository.
 
### Why do you need this?
We do need a designated group of people that can review and merge PRs in this repository. 

### What else do we need to know?
n/a

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
