### PR TITLE
feat(new-admin): add sgtpooki

### DIFF
--- a/github/ipfs-examples.yml
+++ b/github/ipfs-examples.yml
@@ -9,6 +9,7 @@ members:
     - BigLep
     - galargh
     - lidel
+    - sgtpooki
   member:
     - hacdias
     - hugomrdias


### PR DESCRIPTION
need permissions to create helia example repos

### Summary

Adding SgtPooki to admin for ipfs-examples so new examples can be added easily.

### Why do you need this?
Needed in order to create helia example repos according to instructions at https://github.com/ipfs-examples/helia-examples#how-to-add-a-new-example

### What else do we need to know?

It could be better if we directed people to *this* repo if simply adding an additional repo in this file would create it and allow the pulling from the root to work properly. 

thoughts @achingbrain @galargh ?

**DRI:** @SgtPooki
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
