### PR TITLE
feat: add helia-ts-node example repo

### DIFF
--- a/github/ipfs-examples.yml
+++ b/github/ipfs-examples.yml
@@ -422,6 +422,35 @@ repositories:
       repository: example-fork-go-template
     visibility: public
     vulnerability_alerts: true
+  helia-ts-node:
+    advanced_security: false
+    allow_auto_merge: false
+    allow_merge_commit: true
+    allow_rebase_merge: true
+    allow_squash_merge: true
+    allow_update_branch: false
+    archived: false
+    auto_init: false
+    default_branch: main
+    delete_branch_on_merge: false
+    description: Running Helia with ts-node
+    has_discussions: false
+    has_downloads: true
+    has_issues: true
+    has_projects: false
+    has_wiki: false
+    is_template: false
+    merge_commit_message: PR_TITLE
+    merge_commit_title: MERGE_MESSAGE
+    secret_scanning_push_protection: true
+    secret_scanning: true
+    squash_merge_commit_message: COMMIT_MESSAGES
+    squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    template:
+      owner: ipfs-examples
+      repository: example-fork-go-template
+    visibility: public
+    vulnerability_alerts: true
   helia-vite:
     advanced_security: false
     allow_auto_merge: false


### PR DESCRIPTION
### Summary

Adds a repo for an example of how to use Helia with ts-node

### Why do you need this?

To show people how to use Helia with ts-node

### What else do we need to know?

Nothing.

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
