### PR TITLE
fix: rename helia-jest to helia-jest-typescript

### DIFF
--- a/github/ipfs-examples.yml
+++ b/github/ipfs-examples.yml
@@ -335,7 +335,7 @@ repositories:
         - ipjs
     visibility: public
     vulnerability_alerts: false
-  helia-jest:
+  helia-jest-typescript:
     advanced_security: false
     allow_auto_merge: false
     allow_merge_commit: true
@@ -346,7 +346,7 @@ repositories:
     auto_init: false
     default_branch: main
     delete_branch_on_merge: false
-    description: Test Helia with Jest
+    description: Test Helia with Jest and TypeScript
     has_discussions: false
     has_downloads: true
     has_issues: true


### PR DESCRIPTION
### Summary

Rename helia-jest repo to helia-jest-typescript

### Why do you need this?

The example is jest+typescript specific so rename the repo to allow for a generic jest example at a later date.

### What else do we need to know?

Nothing.

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
