### PR TITLE
Reduce org owners/admins

### DIFF
--- a/github/ipfs-examples.yml
+++ b/github/ipfs-examples.yml
@@ -5,15 +5,15 @@ members:
     - 2color
     - achingbrain
     - andyschwab-admin
+    - galargh
+    - lidel
+  member:
     - aschmahmann
     - autonome
     - BigLep
-    - galargh
-    - lidel
-    - SgtPooki
-  member:
     - hacdias
     - whizzzkid
+    - SgtPooki
 repositories:
   actions-pull-directory-from-repo:
     advanced_security: false

--- a/github/ipfs-examples.yml
+++ b/github/ipfs-examples.yml
@@ -12,8 +12,8 @@ members:
     - autonome
     - BigLep
     - hacdias
-    - whizzzkid
     - SgtPooki
+    - whizzzkid
 repositories:
   actions-pull-directory-from-repo:
     advanced_security: false


### PR DESCRIPTION
### Summary
This aligns with the "reduce org owners" step listed in https://github.com/ipfs/ipfs/issues/511.

This is the first step of wider 2024Q1 permissions cleanup.

### Why do you need this?
Github org safety.  See https://github.com/ipfs/ipfs/issues/511 for more info.

### Timeline
- [ ] 2024-02-12: public PR
- [ ] 2024-02-12: notify affected parties: 
- [ ] 2024-02-14: merge this change assuming no major pushback

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request